### PR TITLE
add full-precision maxLiquidityForAmount0

### DIFF
--- a/src/entities/position.test.ts
+++ b/src/entities/position.test.ts
@@ -186,7 +186,7 @@ describe('Position', () => {
         })
 
         const { amount0, amount1 } = position.mintAmountsWithSlippage(slippageTolerance)
-        expect(amount0.toString()).toEqual('49949961958869841754182')
+        expect(amount0.toString()).toEqual('49949961958869841738198')
         expect(amount1.toString()).toEqual('0')
       })
 
@@ -212,7 +212,7 @@ describe('Position', () => {
         })
 
         const { amount0, amount1 } = position.mintAmountsWithSlippage(slippageTolerance)
-        expect(amount0.toString()).toEqual('120054069145287995769397')
+        expect(amount0.toString()).toEqual('120054069145287995740584')
         expect(amount1.toString()).toEqual('79831926243')
       })
     })
@@ -229,7 +229,7 @@ describe('Position', () => {
         })
 
         const { amount0, amount1 } = position.mintAmountsWithSlippage(slippageTolerance)
-        expect(amount0.toString()).toEqual('49949961958869841754182')
+        expect(amount0.toString()).toEqual('49949961958869841738198')
         expect(amount1.toString()).toEqual('0')
       })
 
@@ -255,7 +255,7 @@ describe('Position', () => {
         })
 
         const { amount0, amount1 } = position.mintAmountsWithSlippage(slippageTolerance)
-        expect(amount0.toString()).toEqual('95063440240746211454823')
+        expect(amount0.toString()).toEqual('95063440240746211432007')
         expect(amount1.toString()).toEqual('54828800461')
       })
     })

--- a/src/entities/position.ts
+++ b/src/entities/position.ts
@@ -156,18 +156,27 @@ export class Position {
       TickMath.getTickAtSqrtRatio(sqrtRatioX96Upper)
     )
 
+    // because the router is imprecise, we need to calculate the position that will be created (assuming no slippage)
+    const positionThatWillBeCreated = Position.fromAmounts({
+      pool: this.pool,
+      tickLower: this.tickLower,
+      tickUpper: this.tickUpper,
+      ...this.mintAmounts, // the mint amounts are what will be passed as calldata
+      useFullPrecision: false
+    })
+
     // we want the smaller amounts...
     // ...which occurs at the upper price for amount0...
     const { amount0 } = new Position({
       pool: poolUpper,
-      liquidity: this.liquidity,
+      liquidity: positionThatWillBeCreated.liquidity,
       tickLower: this.tickLower,
       tickUpper: this.tickUpper
     }).mintAmounts
     // ...and the lower for amount1
     const { amount1 } = new Position({
       pool: poolLower,
-      liquidity: this.liquidity,
+      liquidity: positionThatWillBeCreated.liquidity,
       tickLower: this.tickLower,
       tickUpper: this.tickUpper
     }).mintAmounts
@@ -278,19 +287,23 @@ export class Position {
    * @param tickUpper the upper tick of the position
    * @param amount0 token0 amount
    * @param amount1 token1 amount
+   * @param useFullPrecision if true, liquidity will be maximized according to what the router can calculate,
+   * not what core can theoretically support
    */
   public static fromAmounts({
     pool,
     tickLower,
     tickUpper,
     amount0,
-    amount1
+    amount1,
+    useFullPrecision
   }: {
     pool: Pool
     tickLower: number
     tickUpper: number
     amount0: BigintIsh
     amount1: BigintIsh
+    useFullPrecision: boolean
   }) {
     const sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(tickLower)
     const sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(tickUpper)
@@ -298,7 +311,14 @@ export class Position {
       pool,
       tickLower,
       tickUpper,
-      liquidity: maxLiquidityForAmounts(pool.sqrtRatioX96, sqrtRatioAX96, sqrtRatioBX96, amount0, amount1)
+      liquidity: maxLiquidityForAmounts(
+        pool.sqrtRatioX96,
+        sqrtRatioAX96,
+        sqrtRatioBX96,
+        amount0,
+        amount1,
+        useFullPrecision
+      )
     })
   }
 
@@ -308,19 +328,23 @@ export class Position {
    * @param tickLower the lower tick
    * @param tickUpper the upper tick
    * @param amount0 the desired amount of token0
+   * @param useFullPrecision if true, liquidity will be maximized according to what the router can calculate,
+   * not what core can theoretically support
    */
   public static fromAmount0({
     pool,
     tickLower,
     tickUpper,
-    amount0
+    amount0,
+    useFullPrecision
   }: {
     pool: Pool
     tickLower: number
     tickUpper: number
     amount0: BigintIsh
+    useFullPrecision: boolean
   }) {
-    return Position.fromAmounts({ pool, tickLower, tickUpper, amount0, amount1: MaxUint256 })
+    return Position.fromAmounts({ pool, tickLower, tickUpper, amount0, amount1: MaxUint256, useFullPrecision })
   }
 
   /**
@@ -341,6 +365,7 @@ export class Position {
     tickUpper: number
     amount1: BigintIsh
   }) {
-    return Position.fromAmounts({ pool, tickLower, tickUpper, amount0: MaxUint256, amount1 })
+    // this function always uses full precision,
+    return Position.fromAmounts({ pool, tickLower, tickUpper, amount0: MaxUint256, amount1, useFullPrecision: true })
   }
 }

--- a/src/entities/position.ts
+++ b/src/entities/position.ts
@@ -287,7 +287,7 @@ export class Position {
    * @param tickUpper the upper tick of the position
    * @param amount0 token0 amount
    * @param amount1 token1 amount
-   * @param useFullPrecision if true, liquidity will be maximized according to what the router can calculate,
+   * @param useFullPrecision if false, liquidity will be maximized according to what the router can calculate,
    * not what core can theoretically support
    */
   public static fromAmounts({

--- a/src/utils/maxLiquidityForAmounts.test.ts
+++ b/src/utils/maxLiquidityForAmounts.test.ts
@@ -4,117 +4,253 @@ import { encodeSqrtRatioX96 } from './encodeSqrtRatioX96'
 import { maxLiquidityForAmounts } from './maxLiquidityForAmounts'
 
 describe('#maxLiquidityForAmounts', () => {
-  describe('price inside', () => {
-    it('100 token0, 200 token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(1, 1),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          '100',
-          '200'
-        )
-      ).toEqual(JSBI.BigInt(2148))
+  describe('imprecise', () => {
+    describe('price inside', () => {
+      it('100 token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(1, 1),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            '200',
+            false
+          )
+        ).toEqual(JSBI.BigInt(2148))
+      })
+
+      it('100 token0, max token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(1, 1),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            MaxUint256,
+            false
+          )
+        ).toEqual(JSBI.BigInt(2148))
+      })
+
+      it('max token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(1, 1),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            MaxUint256,
+            '200',
+            false
+          )
+        ).toEqual(JSBI.BigInt(4297))
+      })
     })
 
-    it('100 token0, max token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(1, 1),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          '100',
-          MaxUint256
-        )
-      ).toEqual(JSBI.BigInt(2148))
+    describe('price below', () => {
+      it('100 token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(99, 110),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            '200',
+            false
+          )
+        ).toEqual(JSBI.BigInt(1048))
+      })
+
+      it('100 token0, max token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(99, 110),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            MaxUint256,
+            false
+          )
+        ).toEqual(JSBI.BigInt(1048))
+      })
+
+      it('max token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(99, 110),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            MaxUint256,
+            '200',
+            false
+          )
+        ).toEqual(JSBI.BigInt('1214437677402050006470401421068302637228917309992228326090730924516431320489727'))
+      })
     })
 
-    it('max token0, 200 token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(1, 1),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          MaxUint256,
-          '200'
-        )
-      ).toEqual(JSBI.BigInt(4297))
+    describe('price above', () => {
+      it('100 token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(111, 100),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            '200',
+            false
+          )
+        ).toEqual(JSBI.BigInt(2097))
+      })
+
+      it('100 token0, max token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(111, 100),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            MaxUint256,
+            false
+          )
+        ).toEqual(JSBI.BigInt('1214437677402050006470401421098959354205873606971497132040612572422243086574654'))
+      })
+
+      it('max token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(111, 100),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            MaxUint256,
+            '200',
+            false
+          )
+        ).toEqual(JSBI.BigInt(2097))
+      })
     })
   })
 
-  describe('price below', () => {
-    it('100 token0, 200 token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(99, 110),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          '100',
-          '200'
-        )
-      ).toEqual(JSBI.BigInt(1048))
+  describe('precise', () => {
+    describe('price inside', () => {
+      it('100 token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(1, 1),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            '200',
+            true
+          )
+        ).toEqual(JSBI.BigInt(2148))
+      })
+
+      it('100 token0, max token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(1, 1),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            MaxUint256,
+            true
+          )
+        ).toEqual(JSBI.BigInt(2148))
+      })
+
+      it('max token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(1, 1),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            MaxUint256,
+            '200',
+            true
+          )
+        ).toEqual(JSBI.BigInt(4297))
+      })
     })
 
-    it('100 token0, max token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(99, 110),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          '100',
-          MaxUint256
-        )
-      ).toEqual(JSBI.BigInt(1048))
+    describe('price below', () => {
+      it('100 token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(99, 110),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            '200',
+            true
+          )
+        ).toEqual(JSBI.BigInt(1048))
+      })
+
+      it('100 token0, max token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(99, 110),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            MaxUint256,
+            true
+          )
+        ).toEqual(JSBI.BigInt(1048))
+      })
+
+      it('max token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(99, 110),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            MaxUint256,
+            '200',
+            true
+          )
+        ).toEqual(JSBI.BigInt('1214437677402050006470401421082903520362793114274352355276488318240158678126184'))
+      })
     })
 
-    it('max token0, 200 token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(99, 110),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          MaxUint256,
-          '200'
-        )
-      ).toEqual(JSBI.BigInt('1214437677402050006470401421068302637228917309992228326090730924516431320489727'))
-    })
-  })
+    describe('price above', () => {
+      it('100 token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(111, 100),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            '200',
+            true
+          )
+        ).toEqual(JSBI.BigInt(2097))
+      })
 
-  describe('price above', () => {
-    it('100 token0, 200 token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(111, 100),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          '100',
-          '200'
-        )
-      ).toEqual(JSBI.BigInt(2097))
-    })
+      it('100 token0, max token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(111, 100),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            '100',
+            MaxUint256,
+            true
+          )
+        ).toEqual(JSBI.BigInt('1214437677402050006470401421098959354205873606971497132040612572422243086574654'))
+      })
 
-    it('100 token0, max token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(111, 100),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          '100',
-          MaxUint256
-        )
-      ).toEqual(JSBI.BigInt('1214437677402050006470401421098959354205873606971497132040612572422243086574654'))
-    })
-
-    it('max token0, 200 token1', () => {
-      expect(
-        maxLiquidityForAmounts(
-          encodeSqrtRatioX96(111, 100),
-          encodeSqrtRatioX96(100, 110),
-          encodeSqrtRatioX96(110, 100),
-          MaxUint256,
-          '200'
-        )
-      ).toEqual(JSBI.BigInt(2097))
+      it('max token0, 200 token1', () => {
+        expect(
+          maxLiquidityForAmounts(
+            encodeSqrtRatioX96(111, 100),
+            encodeSqrtRatioX96(100, 110),
+            encodeSqrtRatioX96(110, 100),
+            MaxUint256,
+            '200',
+            true
+          )
+        ).toEqual(JSBI.BigInt(2097))
+      })
     })
   })
 })

--- a/src/utils/maxLiquidityForAmounts.ts
+++ b/src/utils/maxLiquidityForAmounts.ts
@@ -36,7 +36,7 @@ function maxLiquidityForAmount1(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, amount
  * @param sqrtRatioBX96 price at upper boundary
  * @param amount0 token0 amount
  * @param amount1 token1 amount
- * @param useFullPrecision if true, liquidity will be maximized according to what the router can calculate,
+ * @param useFullPrecision if false, liquidity will be maximized according to what the router can calculate,
  * not what core can theoretically support
  */
 export function maxLiquidityForAmounts(

--- a/src/utils/maxLiquidityForAmounts.ts
+++ b/src/utils/maxLiquidityForAmounts.ts
@@ -2,12 +2,23 @@ import { BigintIsh } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 import { Q96 } from '../internalConstants'
 
-function maxLiquidityForAmount0(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, amount0: BigintIsh): JSBI {
+function maxLiquidityForAmount0Imprecise(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, amount0: BigintIsh): JSBI {
   if (JSBI.greaterThan(sqrtRatioAX96, sqrtRatioBX96)) {
     ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
   }
   const intermediate = JSBI.divide(JSBI.multiply(sqrtRatioAX96, sqrtRatioBX96), Q96)
   return JSBI.divide(JSBI.multiply(JSBI.BigInt(amount0), intermediate), JSBI.subtract(sqrtRatioBX96, sqrtRatioAX96))
+}
+
+function maxLiquidityForAmount0Precise(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, amount0: BigintIsh): JSBI {
+  if (JSBI.greaterThan(sqrtRatioAX96, sqrtRatioBX96)) {
+    ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
+  }
+
+  const numerator = JSBI.multiply(JSBI.multiply(JSBI.BigInt(amount0), sqrtRatioAX96), sqrtRatioBX96)
+  const denominator = JSBI.multiply(Q96, JSBI.subtract(sqrtRatioBX96, sqrtRatioAX96))
+
+  return JSBI.divide(numerator, denominator)
 }
 
 function maxLiquidityForAmount1(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, amount1: BigintIsh): JSBI {
@@ -25,17 +36,23 @@ function maxLiquidityForAmount1(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, amount
  * @param sqrtRatioBX96 price at upper boundary
  * @param amount0 token0 amount
  * @param amount1 token1 amount
+ * @param useFullPrecision if true, liquidity will be maximized according to what the router can calculate,
+ * not what core can theoretically support
  */
 export function maxLiquidityForAmounts(
   sqrtRatioCurrentX96: JSBI,
   sqrtRatioAX96: JSBI,
   sqrtRatioBX96: JSBI,
   amount0: BigintIsh,
-  amount1: BigintIsh
+  amount1: BigintIsh,
+  useFullPrecision: boolean
 ): JSBI {
   if (JSBI.greaterThan(sqrtRatioAX96, sqrtRatioBX96)) {
     ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
   }
+
+  const maxLiquidityForAmount0 = useFullPrecision ? maxLiquidityForAmount0Precise : maxLiquidityForAmount0Imprecise
+
   if (JSBI.lessThanOrEqual(sqrtRatioCurrentX96, sqrtRatioAX96)) {
     return maxLiquidityForAmount0(sqrtRatioAX96, sqrtRatioBX96, amount0)
   } else if (JSBI.lessThan(sqrtRatioCurrentX96, sqrtRatioBX96)) {


### PR DESCRIPTION
I think there is another, possibly better, option here which involves implementing the inverse of `maxLiquidityForAmount0Imprecise`.

Assuming we've already calculated the (full precision) max liquidity position that a user is willing to fund (calculated against some desired token amount), we could use the inverse of `maxLiquidityForAmount0Imprecise` to calculate the `amount0Desired` that _would be required_ for the router to calculate (via the imprecise `getLiquidityForAmount0`) the actual max liquidity that we know the user can fund, even if that `amount0Desired` would, in a full-precision setting, result in a liquidity position too large to fund.

The only uncertainty I have about this approach is that if the price moves epsilon away from the current, will this "too-large" `amount0Desired` ever lead to an actually too-large position, due to differences in rounding at different prices? My intuition is that it would not, but I'm not sure...